### PR TITLE
update rubyzip dependency

### DIFF
--- a/neography.gemspec
+++ b/neography.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency "excon", ">= 0.33.0"
   s.add_dependency "json", ">= 1.7.7"
   s.add_dependency "os", ">= 0.9.6"
-  s.add_dependency "rubyzip", ">= 1.0.0"
+  s.add_dependency "rubyzip", ">= 1.2.1"
   s.add_dependency "multi_json", ">= 1.3.2"
 
   if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then


### PR DESCRIPTION
rubyzip had a security vulnerability that was corrected
in version 1.2.1
https://github.com/rubyzip/rubyzip/issues/315

Pivotal Story: https://www.pivotaltracker.com/story/show/145704021

This will require a PR in Doximity too,  to point the gem to the revised branch

It looks like the only usage of rubyzip in this gem is in some of the rake tasks